### PR TITLE
feat: keyarea page into buttons components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import Homepage from "./pages/Homepage";
 import Page404 from "./pages/Page404";
-import Dashboard from "./pages/Keyarea";
+import Keyarea from "./pages/Keyarea"; // Updated import from Dashboard to Keyarea
 import Focus from "./pages/Focus";
 import DummyFocus2 from "./pages/DummyFocus2";
 
@@ -14,7 +14,7 @@ const App: React.FC = () => {
         <Navbar />
         <Routes>
           <Route path="/" element={<Homepage />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/keyarea" element={<Keyarea />} /> {/* Updated path */}
           <Route path="/focus" element={<Focus />} />
           <Route path="/dummy-focus" element={<DummyFocus2 />} />
           <Route path="*" element={<Page404 />} />

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -9,7 +9,14 @@ interface ButtonProps {
 
 const Button: React.FC<ButtonProps> = ({ label, onClick, type = 'button', disabled = false }) => {
   return (
-    <button type={type} onClick={onClick} disabled={disabled}>
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`w-full py-1 px-3 text-white font-medium rounded-md
+        ${disabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-green-500 hover:bg-green-600'}
+        focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75 text-sm`}
+    >
       {label}
     </button>
   );

--- a/client/src/pages/Keyarea.tsx
+++ b/client/src/pages/Keyarea.tsx
@@ -1,38 +1,63 @@
-import React from "react";
+import React, { useState } from "react";
+import Button from "../components/Button";
 
-interface DashboardProps {
+
+interface KeyareaProps {
   // Define any props here
 }
 
-//dashboard component
-const Dashboard: React.FC<DashboardProps> = () => {
+const Keyarea: React.FC<KeyareaProps> = () => {
+  const [activeArea, setActiveArea] = useState<string | null>(null);
+
+  const handleButtonClick = (area: string) => {
+    setActiveArea(area);
+  };
+
   return (
     <div className="flex flex-wrap">
-      {/* activities */}
+      {/* Expected Results Button */}
       <div className="w-full md:w-1/3 p-4">
-        <div className="bg-white border rounded-lg p-6 shadow-sm">
-          <h2 className="text-xl font-semibold mb-2">Activities</h2>
-          <p className="text-gray-700">Content related to activities...</p>
-        </div>
+        <Button
+          label="Expected Results"
+          onClick={() => handleButtonClick("expectedResults")}
+        />
+        {activeArea === "expectedResults" && (
+          <div className="bg-white border rounded-lg p-6 shadow-sm">
+            <h2 className="text-xl font-semibold mb-2">Expected Results</h2>
+            <p className="text-gray-700">Content related to expected results...</p>
+          </div>
+        )}
       </div>
 
-      {/* indicators  */}
+      {/* Indicators Button */}
       <div className="w-full md:w-1/3 p-4">
-        <div className="bg-white border rounded-lg p-6 shadow-sm">
-          <h2 className="text-xl font-semibold mb-2">Indicators</h2>
-          <p className="text-gray-700">Content related to indicators...</p>
-        </div>
+        <Button
+          label="Indicators"
+          onClick={() => handleButtonClick("indicators")}
+        />
+        {activeArea === "indicators" && (
+          <div className="bg-white border rounded-lg p-6 shadow-sm">
+            <h2 className="text-xl font-semibold mb-2">Indicators</h2>
+            <p className="text-gray-700">Content related to indicators...</p>
+          </div>
+        )}
       </div>
 
-      {/* targets */}
+      {/* Targets Button */}
       <div className="w-full md:w-1/3 p-4">
-        <div className="bg-white border rounded-lg p-6 shadow-sm">
-          <h2 className="text-xl font-semibold mb-2">Targets</h2>
-          <p className="text-gray-700">Content related to targets...</p>
-        </div>
+        <Button
+          label="Targets"
+          onClick={() => handleButtonClick("targets")}
+        />
+        {activeArea === "targets" && (
+          <div className="bg-white border rounded-lg p-6 shadow-sm">
+            <h2 className="text-xl font-semibold mb-2">Targets</h2>
+            <p className="text-gray-700">Content related to targets...</p>
+          </div>
+        )}
       </div>
     </div>
   );
 };
 
-export default Dashboard;
+export default Keyarea;


### PR DESCRIPTION
Here I: 

- update the `Keyarea `component. I used the `button` component to render each of the three buttons (expected results, indicators, and targets);
- I appropriately changed all the paths and names from `Dashboard` to `Keyarea` in the route component. Also, I updated the `App.tsx` with the appropriate path. Now, when you navigate to `/keyarea,` it will render the Keyarea component. The `/dashboard` route will no longer be available
- I further styled the button component. I added the colour green which is the same as the current navbar, rounder corners, etc...